### PR TITLE
[codex] filter entry hook dispatch by source rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,12 +87,23 @@ context:
           name: "main",
           url: "https://news.ycombinator.com/rss",
           tags: ["tech"],
+          hooks: {
+            exclude: [
+              { title: "/\\bbeta\\b/i" },
+            ],
+          },
         },
       ],
     },
   ],
 }
 ```
+
+`sources[].hooks.include` / `sources[].hooks.exclude` は `entry.discovered`
+由来の `on-new-articles.*` フックに渡す記事を絞り込みます。記事自体は
+SQLite に保存されます。`include` がある場合はどれかのルールに一致した
+記事だけがフック候補になり、`exclude` は常に最終的に抑制します。現在の
+ルール対象は `title` / `url` / `summary` です。
 
 ## 開発
 

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -5,8 +5,11 @@ import type {
   ConfigFile,
   FeedDefinition,
   FeedSourceDefinition,
+  HookEntryRule,
+  SourceHooksConfig,
 } from "../types";
 import { createId } from "../types";
+import { compileHookPattern, HOOK_ENTRY_FIELDS } from "../hooks/filter.ts";
 
 export async function loadConfig(configPath: string): Promise<ConfigFile> {
   const file = Bun.file(configPath);
@@ -80,8 +83,53 @@ function normalizeFeedSources(feed: FeedDefinition): FeedSourceDefinition[] {
               .filter(Boolean),
           }
         : undefined,
+      hooks: normalizeHooksConfig(source.hooks),
     };
   });
+}
+
+function normalizeHooksConfig(
+  hooks: SourceHooksConfig | undefined,
+): SourceHooksConfig | undefined {
+  if (!hooks) {
+    return undefined;
+  }
+
+  const include = normalizeHookRules(hooks.include);
+  const exclude = normalizeHookRules(hooks.exclude);
+  if (!include && !exclude) {
+    return undefined;
+  }
+
+  const normalized: SourceHooksConfig = {};
+  if (include) normalized.include = include;
+  if (exclude) normalized.exclude = exclude;
+  return normalized;
+}
+
+function normalizeHookRules(
+  rules: HookEntryRule[] | undefined,
+): HookEntryRule[] | undefined {
+  const normalized = rules
+    ?.map(normalizeHookRule)
+    .filter((rule) => Object.keys(rule).length > 0);
+  return normalized && normalized.length > 0 ? normalized : undefined;
+}
+
+function normalizeHookRule(rule: HookEntryRule): HookEntryRule {
+  const normalized: HookEntryRule = {};
+
+  for (const field of HOOK_ENTRY_FIELDS) {
+    const pattern = rule[field]?.trim();
+    if (!pattern) {
+      continue;
+    }
+
+    compileHookPattern(pattern);
+    normalized[field] = pattern;
+  }
+
+  return normalized;
 }
 
 export async function addFeedToConfig(

--- a/src/control-plane/events.ts
+++ b/src/control-plane/events.ts
@@ -10,7 +10,9 @@ import type {
   ScanStartedPayload,
 } from "../contracts/event.ts";
 import type { FeedDatabase } from "../db/index.ts";
+import { shouldDispatchEntryHooks } from "../hooks/filter.ts";
 import type { ResolvedPaths } from "../paths.ts";
+import type { SourceHooksConfig } from "../types.ts";
 import {
   discoverHooks,
   executeHooks,
@@ -18,9 +20,15 @@ import {
 } from "../cron/hooks.ts";
 import { workspaceIdFromBaseDir } from "./identity.ts";
 
+export type EventDispatchPaths =
+  & Pick<ResolvedPaths, "base" | "hooksDir" | "hooksEnabled">
+  & {
+    sourceHookConfigs?: ReadonlyMap<string, SourceHooksConfig>;
+  };
+
 export async function dispatchPendingEvents(
   db: FeedDatabase,
-  paths: Pick<ResolvedPaths, "base" | "hooksDir" | "hooksEnabled">,
+  paths: EventDispatchPaths,
 ): Promise<void> {
   const workspaceId = workspaceIdFromBaseDir(paths.base);
   const pendingEvents = db.listDispatchableEvents(workspaceId);
@@ -28,6 +36,11 @@ export async function dispatchPendingEvents(
   for (const record of pendingEvents) {
     const hookContext = hookContextForEvent(record.event);
     if (!paths.hooksEnabled) {
+      db.markEventDispatched(record.event.id);
+      continue;
+    }
+
+    if (!shouldDispatchHooksForEvent(record.event, paths.sourceHookConfigs)) {
       db.markEventDispatched(record.event.id);
       continue;
     }
@@ -85,6 +98,21 @@ export async function dispatchPendingEvents(
 
     db.markEventDispatched(record.event.id);
   }
+}
+
+function shouldDispatchHooksForEvent(
+  event: EventEnvelope,
+  sourceHookConfigs: ReadonlyMap<string, SourceHooksConfig> | undefined,
+): boolean {
+  if (event.kind !== "entry.discovered") {
+    return true;
+  }
+
+  const payload = event.payload as EntryDiscoveredPayload;
+  return shouldDispatchEntryHooks(
+    payload,
+    sourceHookConfigs?.get(payload.sourceId),
+  );
 }
 
 function hookContextForEvent(event: EventEnvelope): HookContext {

--- a/src/cron/index.ts
+++ b/src/cron/index.ts
@@ -18,6 +18,7 @@ import {
 } from "../control-plane/identity.ts";
 import { HEARTBEAT_CRON_SCHEDULE } from "../control-plane/heartbeat.ts";
 import { FeedDatabase } from "../db/index.ts";
+import { sourceHookConfigsFromConfig } from "../hooks/filter.ts";
 import { ensureDir, type ResolvedPaths } from "../paths.ts";
 import { scanFeed, type ScanResult } from "../scanner.ts";
 import type { CycleTrigger } from "../types.ts";
@@ -73,6 +74,7 @@ export async function runCycle(
   const config = await loadConfig(paths.config);
   const workspaceId = workspaceIdFromBaseDir(paths.base);
   const pipelineId = defaultPipelineId(workspaceId);
+  const sourceHookConfigs = sourceHookConfigsFromConfig(config);
 
   if (config.feeds.length === 0) {
     outputWarn("No feeds in config, skipping cycle.");
@@ -158,7 +160,7 @@ export async function runCycle(
             "entry.discovered",
             {
               entryId: article.id as EntryDiscoveredPayload["entryId"],
-              sourceId: (sourceIds[0] ?? "") as EntryDiscoveredPayload["sourceId"],
+              sourceId: article.sourceId as EntryDiscoveredPayload["sourceId"],
               scanRunId: cycleId as EntryDiscoveredPayload["scanRunId"],
               discoveredAt: nowIso(),
               feedId: feedId || result.feedId,
@@ -204,7 +206,7 @@ export async function runCycle(
       ),
     );
 
-    await dispatchPendingEvents(db, paths);
+    await dispatchPendingEvents(db, { ...paths, sourceHookConfigs });
     db.pruneLogs();
     outputInfo(`Cycle complete: ${totalNew} new articles in ${durationMs}ms`);
   } catch (err) {

--- a/src/hooks/filter.ts
+++ b/src/hooks/filter.ts
@@ -1,0 +1,103 @@
+import type { EntryDiscoveredPayload } from "../contracts/event.ts";
+import type {
+  ConfigFile,
+  HookEntryField,
+  HookEntryRule,
+  SourceHooksConfig,
+} from "../types.ts";
+
+export const HOOK_ENTRY_FIELDS = ["title", "url", "summary"] as const satisfies readonly HookEntryField[];
+
+type HookEntry = Pick<EntryDiscoveredPayload, "title" | "url" | "summary">;
+
+export function sourceHookConfigsFromConfig(
+  config: ConfigFile,
+): ReadonlyMap<string, SourceHooksConfig> {
+  const sourceHooks = new Map<string, SourceHooksConfig>();
+
+  for (const feed of config.feeds) {
+    for (const source of feed.sources) {
+      if (source.id && source.hooks) {
+        sourceHooks.set(source.id, source.hooks);
+      }
+    }
+  }
+
+  return sourceHooks;
+}
+
+export function shouldDispatchEntryHooks(
+  entry: HookEntry,
+  hooks?: SourceHooksConfig,
+): boolean {
+  if (!hooks) return true;
+
+  if (hooks.include?.length && !hooks.include.some((rule) => matchesRule(entry, rule))) {
+    return false;
+  }
+
+  if (hooks.exclude?.some((rule) => matchesRule(entry, rule))) {
+    return false;
+  }
+
+  return true;
+}
+
+export function compileHookPattern(pattern: string): RegExp {
+  const trimmed = pattern.trim();
+  const literal = parseRegexLiteral(trimmed);
+  return literal ?? new RegExp(trimmed);
+}
+
+function matchesRule(entry: HookEntry, rule: HookEntryRule): boolean {
+  let matchedFields = 0;
+
+  for (const field of HOOK_ENTRY_FIELDS) {
+    const pattern = rule[field];
+    if (!pattern) continue;
+
+    matchedFields++;
+    const value = entry[field] ?? "";
+    if (!compileHookPattern(pattern).test(value)) {
+      return false;
+    }
+  }
+
+  return matchedFields > 0;
+}
+
+function parseRegexLiteral(input: string): RegExp | null {
+  if (!input.startsWith("/") || input.length < 2) {
+    return null;
+  }
+
+  const separatorIndex = findLastUnescapedSlash(input);
+  if (separatorIndex <= 0) {
+    return null;
+  }
+
+  const flags = input.slice(separatorIndex + 1);
+  if (!/^[dgimsuvy]*$/.test(flags)) {
+    return null;
+  }
+
+  return new RegExp(input.slice(1, separatorIndex), flags);
+}
+
+function findLastUnescapedSlash(input: string): number {
+  for (let i = input.length - 1; i > 0; i--) {
+    if (input[i] === "/" && !isEscaped(input, i)) {
+      return i;
+    }
+  }
+
+  return -1;
+}
+
+function isEscaped(input: string, index: number): boolean {
+  let backslashes = 0;
+  for (let i = index - 1; i >= 0 && input[i] === "\\"; i--) {
+    backslashes++;
+  }
+  return backslashes % 2 === 1;
+}

--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -19,6 +19,7 @@ export interface ScanResult {
 
 export interface NewArticle {
   id: string;
+  sourceId: string;
   title: string;
   url: string;
   publishedAt: string | null;
@@ -88,6 +89,7 @@ export async function scanFeed(
         result.articlesInserted++;
         result.newArticles.push({
           id,
+          sourceId: dbSource.id,
           title: article.title,
           url: article.url,
           publishedAt: article.publishedAt,

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,6 +13,15 @@ export interface SitemapConfig {
   exclude?: string[];
 }
 
+export type HookEntryField = "title" | "url" | "summary";
+
+export type HookEntryRule = Partial<Record<HookEntryField, string>>;
+
+export interface SourceHooksConfig {
+  include?: HookEntryRule[];
+  exclude?: HookEntryRule[];
+}
+
 export type SourceKind =
   | "rss"
   | "atom"
@@ -30,6 +39,7 @@ export interface FeedSourceDefinition {
   tags?: string[];
   scrape?: ScrapeConfig;
   sitemap?: SitemapConfig;
+  hooks?: SourceHooksConfig;
 }
 
 export interface FeedDefinition {

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -122,6 +122,10 @@ describe("config", () => {
               include: [" /posts/ ", " "],
               exclude: [" /drafts/ "],
             },
+            hooks: {
+              include: [{ title: " stable ", url: " /releases/ " }, {}],
+              exclude: [{ title: " /beta/i ", summary: " preview " }],
+            },
           },
         ],
       });
@@ -140,6 +144,10 @@ describe("config", () => {
         include: ["/posts/"],
         exclude: ["/drafts/"],
       });
+      expect(result.sources?.[0].hooks).toEqual({
+        include: [{ title: "stable", url: "/releases/" }],
+        exclude: [{ title: "/beta/i", summary: "preview" }],
+      });
     });
 
     test("assigns source ids and defaults tags to empty array", () => {
@@ -150,6 +158,21 @@ describe("config", () => {
       expect(result.sources?.[0].id).toBeString();
       expect(result.sources?.[0].tags).toEqual([]);
       expect(result.sources?.[0].scrape).toBeUndefined();
+    });
+
+    test("rejects invalid source hook regex patterns", () => {
+      expect(() =>
+        normalizeFeedDefinition({
+          name: "Test",
+          sources: [
+            {
+              name: "main",
+              url: "https://example.com",
+              hooks: { exclude: [{ title: "[" }] },
+            },
+          ],
+        }),
+      ).toThrow("Invalid regular expression");
     });
 
     test("requires at least one source", () => {

--- a/tests/control-plane.test.ts
+++ b/tests/control-plane.test.ts
@@ -132,6 +132,62 @@ describe("control plane phase 1", () => {
     expect(Number(hookRunCount.count)).toBe(1);
   });
 
+  test("dispatchPendingEvents skips entry hooks excluded by source hook rules", async () => {
+    const root = await mkdtemp(join(tmpdir(), "feeds-control-plane-filter-"));
+    tempRoots.push(root);
+    const hooksDir = join(root, "hooks");
+    const outFile = join(root, "hook-output.json");
+    const dbPath = join(root, "feeds.db");
+
+    await mkdir(hooksDir, { recursive: true });
+    await writeFile(
+      join(hooksDir, "on-new-articles.sh"),
+      `#!/bin/sh\ncat > "${outFile}"\n`,
+      { mode: 0o755 },
+    );
+
+    using db = new FeedDatabase(dbPath);
+    const workspaceId = workspaceIdFromBaseDir(root);
+    const pipelineId = defaultPipelineId(workspaceId);
+
+    db.insertEvent({
+      id: crypto.randomUUID() as EventEnvelope["id"],
+      kind: "entry.discovered",
+      workspaceId,
+      pipelineId,
+      occurredAt: new Date().toISOString() as EventEnvelope["occurredAt"],
+      payload: {
+        entryId: "entry-1",
+        sourceId: "source-1",
+        scanRunId: "scan-1",
+        discoveredAt: new Date().toISOString(),
+        feedId: "feed-1",
+        feedName: "openclaw",
+        title: "OpenClaw beta release",
+        url: "https://example.com/releases/beta",
+        publishedAt: null,
+        summary: "Preview release",
+      },
+    });
+
+    await dispatchPendingEvents(db, {
+      base: root,
+      hooksDir,
+      hooksEnabled: true,
+      sourceHookConfigs: new Map([
+        ["source-1", { exclude: [{ title: "/beta/i" }] }],
+      ]),
+    });
+
+    expect(await Bun.file(outFile).exists()).toBe(false);
+    expect(db.countEventsByStatus(workspaceId, "dispatched")).toBe(1);
+
+    const hookRunCount = db.sqlite
+      .query("SELECT COUNT(*) as count FROM hook_runs")
+      .get() as { count: number | bigint };
+    expect(Number(hookRunCount.count)).toBe(0);
+  });
+
   test("failed event retry skips hooks that already succeeded", async () => {
     const root = await mkdtemp(join(tmpdir(), "feeds-control-plane-retry-"));
     tempRoots.push(root);

--- a/tests/cron.test.ts
+++ b/tests/cron.test.ts
@@ -1,9 +1,29 @@
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-import { access, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { access, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { intervalToCron, maybeRunHooks, prepareCyclePaths } from "../src/cron/index";
+import { intervalToCron, maybeRunHooks, prepareCyclePaths, runCycle } from "../src/cron/index";
 import { renderCronCheck, renderCronStatus } from "../src/cli/commands/cron";
+import { FeedDatabase } from "../src/db";
+import { resolvePaths } from "../src/paths";
+
+const BETA_RSS_FIXTURE = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>OpenClaw Releases</title>
+    <link>https://example.com</link>
+    <description>Releases</description>
+    <item>
+      <title>OpenClaw 2026.5.27 Beta</title>
+      <link>https://example.com/releases/beta</link>
+      <guid>https://example.com/releases/beta</guid>
+      <pubDate>Wed, 27 May 2026 00:00:00 GMT</pubDate>
+      <description>Preview release</description>
+    </item>
+  </channel>
+</rss>`;
+
+const originalFetch = globalThis.fetch;
 
 describe("intervalToCron", () => {
   test("converts minutes to cron expression", () => {
@@ -74,6 +94,73 @@ describe("maybeRunHooks", () => {
     );
 
     expect(await Bun.file(outFile).exists()).toBe(false);
+  });
+});
+
+describe("runCycle hook filters", () => {
+  const tempRoots: string[] = [];
+
+  afterEach(async () => {
+    globalThis.fetch = originalFetch;
+    while (tempRoots.length > 0) {
+      const root = tempRoots.pop();
+      if (root) {
+        await rm(root, { recursive: true, force: true });
+      }
+    }
+  });
+
+  test("keeps excluded entries in storage while skipping new-articles hooks", async () => {
+    const root = await mkdtemp(join(tmpdir(), "feeds-cycle-filter-"));
+    tempRoots.push(root);
+    const paths = resolvePaths({ baseDir: root });
+    const outFile = join(root, "hook-output.json");
+
+    await mkdir(paths.hooksDir, { recursive: true });
+    await writeFile(
+      join(paths.hooksDir, "on-new-articles.sh"),
+      `#!/bin/sh\ncat > "${outFile}"\n`,
+      { mode: 0o755 },
+    );
+    await writeFile(
+      paths.config,
+      `{
+  feeds: [
+    {
+      id: "openclaw",
+      name: "OpenClaw Releases",
+      sources: [
+        {
+          id: "openclaw-releases",
+          name: "GitHub Releases",
+          url: "https://example.com/releases.atom",
+          hooks: {
+            exclude: [{ title: "/beta/i" }],
+          },
+        },
+      ],
+    },
+  ],
+}
+`,
+    );
+    globalThis.fetch = async () => new Response(BETA_RSS_FIXTURE, { status: 200 });
+
+    await runCycle(paths, "manual");
+
+    using db = new FeedDatabase(paths.db);
+    expect(db.listArticles({})).toHaveLength(1);
+    expect(await Bun.file(outFile).exists()).toBe(false);
+
+    const entryEvents = db.sqlite
+      .query("SELECT status FROM events WHERE kind = 'entry.discovered'")
+      .all() as Array<{ status: string }>;
+    expect(entryEvents).toEqual([{ status: "dispatched" }]);
+
+    const hookRunCount = db.sqlite
+      .query("SELECT COUNT(*) as count FROM hook_runs")
+      .get() as { count: number | bigint };
+    expect(Number(hookRunCount.count)).toBe(0);
   });
 });
 

--- a/tests/hooks-filter.test.ts
+++ b/tests/hooks-filter.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test";
+import { shouldDispatchEntryHooks } from "../src/hooks/filter";
+
+const entry = {
+  title: "OpenClaw 2026.5.27 stable",
+  url: "https://example.com/releases/stable",
+  summary: "Stable release",
+};
+
+describe("source hook filters", () => {
+  test("allows entries when no hook filters are configured", () => {
+    expect(shouldDispatchEntryHooks(entry)).toBe(true);
+  });
+
+  test("requires at least one include rule when include is configured", () => {
+    expect(
+      shouldDispatchEntryHooks(entry, {
+        include: [{ title: "/stable/i" }],
+      }),
+    ).toBe(true);
+
+    expect(
+      shouldDispatchEntryHooks(entry, {
+        include: [{ title: "/beta/i" }],
+      }),
+    ).toBe(false);
+  });
+
+  test("lets exclude override matching include rules", () => {
+    expect(
+      shouldDispatchEntryHooks(entry, {
+        include: [{ title: "/stable/i" }],
+        exclude: [{ url: "/releases/stable" }],
+      }),
+    ).toBe(false);
+  });
+
+  test("requires every field in a rule to match", () => {
+    expect(
+      shouldDispatchEntryHooks(entry, {
+        exclude: [{ title: "/stable/i", summary: "/preview/i" }],
+      }),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Add source-level `hooks.include` / `hooks.exclude` rules for `entry.discovered` hook delivery.
- Preserve article storage and event history while suppressing matching `on-new-articles.*` hook dispatch.
- Document the config shape and add coverage for include/exclude semantics and OpenClaw-style beta filtering.

## Why

OpenClaw release feeds produce frequent prerelease entries. The repo-native surface is `hooks`, not a downstream-only `notify` concept, so the filtering rule belongs at `feeds[].sources[].hooks`.

## Validation

- `bun test`
- `bunx tsc --noEmit`
- `git diff --check`

## Operational note

The local production config at `/home/yoshikouki/.feeds-cli/feeds.json5` was updated separately to exclude OpenClaw `alpha`, `beta`, and `rc` release titles from hook delivery while still storing the entries.