### PR TITLE
[codex] Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Check whitespace
+        run: git diff --check
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.12"
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run tests
+        run: bun test
+
+      - name: Type check
+        run: ./node_modules/.bin/tsc --noEmit


### PR DESCRIPTION
## Summary
- Add a GitHub Actions CI workflow for feeds-cli.
- Run the repo's existing Bun install, test, typecheck, and whitespace checks on push and pull requests to main.

## Validation
- bun install --frozen-lockfile
- bun test
- ./node_modules/.bin/tsc --noEmit
- git diff --check
